### PR TITLE
remove data attr from thomson ski checkbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,7 +185,7 @@
 									<input class="checks__input" data-customer="direct" data-brand="crystal" data-season="winter" name="sites" type="checkbox" value="direct/78/"><span>Crystal Ski (direct)</span>
 								</label>
 								<label>
-									<input class="checks__input" data-customer="direct" data-brand="thomson" data-season="winter" name="sites" type="checkbox" value="direct/79/"><span>Thomson Ski (direct)</span>
+									<input class="checks__input" name="sites" type="checkbox" value="direct/79/"><span>Thomson Ski (direct)</span>
 								</label>
 								<label>
 									<input class="checks__input" data-customer="direct" data-brand="crystal" data-season="winter" name="sites" type="checkbox" value="direct/81/"><span>Crystal Ski IE (direct)</span>


### PR DESCRIPTION
mored data attributes from thomson ski checkbox to prevent it from being toggled by side filters
